### PR TITLE
Ensure count returns correct line total

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -111,6 +111,6 @@ class Reader implements Iterator, Countable
     public function count(): int
     {
         $this->file->seek(PHP_INT_MAX);
-        return $this->file->key();
+        return $this->file->key() + 1;
     }
 }

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -75,7 +75,7 @@ class ReaderTest extends TestCase
     public function testCount(): void
     {
         $reader = new Reader($this->root->url() . '/csv/file01.csv');
-        $this->assertSame(4, $reader->count());
+        $this->assertSame(5, $reader->count());
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix Reader::count to include the last line by adding 1 to the file key
- update tests to expect 5 lines in the CSV file

## Testing
- `vendor/bin/phpunit -c phpunit.dist.xml` *(fails: ReaderTest::testTell, ReaderTest::testSeekLines)*

------
https://chatgpt.com/codex/tasks/task_e_689cc769bdbc832ba4e9208b315f5e51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected line counting to return the actual number of lines instead of a zero-based index. Counts may increase by one compared to previous versions, ensuring accurate totals for files.

- Tests
  - Updated test expectations to match the corrected line counting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->