### PR TITLE
Upgrade dependencies and modernize codebase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "pause or resume via tell and seek"
   ],
   "require": {
-    "php": "~7.1 || ~8.0"
+    "php": "^8.3"
   },
   "autoload": {
     "psr-4": {
@@ -23,8 +23,8 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^12.0",
     "mikey179/vfsstream": "^1.6",
-    "rector/rector": "^1.2"
+    "rector/rector": "^2.0"
   }
 }

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="vendor/autoload.php"
-         colors="true">
-
-    <testsuites>
-        <testsuite name="CSV Reader Tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory>src</directory>
-        </include>
-        <report>
-            <clover outputFile="./.phpunit/clover.xml"/>
-            <html outputDirectory="./.phpunit/coverage" lowUpperBound="35" highLowerBound="70"/>
-        </report>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit/cache">
+  <testsuites>
+    <testsuite name="CSV Reader Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -16,4 +16,6 @@ return RectorConfig::configure()
         \Rector\Set\ValueObject\SetList::TYPE_DECLARATION,
         \Rector\Set\ValueObject\SetList::EARLY_RETURN,
         \Rector\Set\ValueObject\SetList::DEAD_CODE,
+        \Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_120,
+        \Rector\PHPUnit\Set\PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
     ]);

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -9,27 +9,7 @@ use SplFileInfo;
 
 class Reader implements Iterator, Countable
 {
-    /**
-     * @var SplFileObject
-     */
-    private $file;
-
-    /**
-     * @var string
-     */
-    private $columnSeparator;
-
-    /**
-     * @var string
-     */
-    private $lineSeparator;
-
-    /**
-     * Column enclosure character
-     *
-     * @var string
-     */
-    private $enclosure;
+    private readonly \SplFileObject $file;
 
     /**
      * Reader constructor.
@@ -38,14 +18,13 @@ class Reader implements Iterator, Countable
      * @param string $enclosure
      * @param string $lineSeparator
      */
-    public function __construct(string $file, $columnSeparator = ',', $enclosure = '', $lineSeparator = PHP_EOL)
+    public function __construct(string $file, private string $columnSeparator = ',', /**
+     * Column enclosure character
+     */
+    private string $enclosure = '', private string $lineSeparator = PHP_EOL)
     {
         $fileInfo = new SplFileInfo($file);
         $this->file = $fileInfo->openFile('rb+');
-
-        $this->columnSeparator = $columnSeparator;
-        $this->lineSeparator = $lineSeparator;
-        $this->enclosure = $enclosure;
 
         $this->next();
     }
@@ -73,9 +52,7 @@ class Reader implements Iterator, Countable
 
         $line = explode($this->columnSeparator, $buffer);
 
-        return array_map(function ($item): string {
-            return trim($item, " \t\n\r\0\x0B\xEF\xBB\xBF" . $this->enclosure);
-        }, $line);
+        return array_map(fn($item): string => trim($item, " \t\n\r\0\x0B\xEF\xBB\xBF" . $this->enclosure), $line);
     }
 
     public function key(): int

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -14,14 +14,14 @@ class ReaderTest extends TestCase
     {
         $this->root = vfsStream::setup('data', 0, [
             'csv' => [
-                'file01.csv' => implode(PHP_EOL, [
+                'file01.csv' => implode("\n", [
                     'A1,B1,C1',
                     'A2,B2,C2',
                     'A3,B3,C3',
                     'A4,B4,C4',
                     'A5,B5,C5',
                 ]),
-                'file02.csv' => implode(PHP_EOL, [
+                'file02.csv' => implode("\n", [
                     'A1|B1|C1',
                     'A2|B2|C2',
                     'A3|B3|C3',
@@ -35,55 +35,49 @@ class ReaderTest extends TestCase
     /**
      * Configurations on column separators
      */
-    public function columnLineSeparatorDataProvider(): array
+    public static function columnLineSeparatorDataProvider(): array
     {
         return [
             'initial file' => [
                 'file' => '/csv/file01.csv',
-                'column separator' => ',',
+                'columnSeparator' => ',',
             ],
             'pipe column separator' => [
                 'file' => '/csv/file02.csv',
-                'column separator' => '|'
+                'columnSeparator' => '|'
             ]
         ];
     }
 
-    /**
-     * @dataProvider columnLineSeparatorDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('columnLineSeparatorDataProvider')]
     public function testReader(string $file, string $columnSeparator): void
     {
-        $reader = new Reader($this->root->url() . $file, $columnSeparator);
+        $reader = new Reader($this->root->url() . $file, $columnSeparator, '', "\n");
         $data = $reader->current();
         $this->assertSame(['A1', 'B1', 'C1'], $data);
         $this->assertSame(1, $reader->key());
     }
 
-    /**
-     * @dataProvider columnLineSeparatorDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('columnLineSeparatorDataProvider')]
     public function testKey(string $file, string $columnSeparator): void
     {
-        $reader = new Reader($this->root->url() . $file, $columnSeparator);
+        $reader = new Reader($this->root->url() . $file, $columnSeparator, '', "\n");
         $reader->next();
         $reader->next();
 
-        $this->assertSame(3, $reader->key());        
+        $this->assertSame(3, $reader->key());
     }
 
     public function testCount(): void
     {
-        $reader = new Reader($this->root->url() . '/csv/file01.csv');
+        $reader = new Reader($this->root->url() . '/csv/file01.csv', ',', '', "\n");
         $this->assertSame(5, $reader->count());
     }
 
-    /**
-     * @dataProvider columnLineSeparatorDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('columnLineSeparatorDataProvider')]
     public function testRewind(string $file, string $columnSeparator): void
     {
-        $reader = new Reader($this->root->url() . $file, $columnSeparator);
+        $reader = new Reader($this->root->url() . $file, $columnSeparator, '', "\n");
         $this->assertSame(['A1', 'B1', 'C1'], $reader->current());
         $this->assertSame(['A2', 'B2', 'C2'], $reader->current());
         $reader->rewind();
@@ -92,18 +86,18 @@ class ReaderTest extends TestCase
 
     public function testTell(): void
     {
-        $reader = new Reader($this->root->url() . '/csv/file01.csv');
+        $reader = new Reader($this->root->url() . '/csv/file01.csv', ',', '', "\n");
         $this->assertSame(0, $reader->tell());
         $reader->current();
-        $this->assertSame(10, $reader->tell());
+        $this->assertSame(9, $reader->tell());
         $reader->current();
-        $this->assertSame(20, $reader->tell());
+        $this->assertSame(18, $reader->tell());
     }
 
     public function testSeekLines(): void
     {
-        $reader = new Reader($this->root->url() . '/csv/file01.csv');
-        $reader->seek(30);
+        $reader = new Reader($this->root->url() . '/csv/file01.csv', ',', '', "\n");
+        $reader->seek(27);
 
         $data = $reader->current();
         $this->assertSame(['A4', 'B4', 'C4'], $data);


### PR DESCRIPTION
The codebase has been upgraded to support PHP 8.3 and PHPUnit 12. Key changes include:
- Upgrading `phpunit/phpunit` to ^12.0 and `rector/rector` to ^2.0.
- Modernizing `Reader.php` with constructor property promotion and typed properties.
- Updating `ReaderTest.php` to use PHPUnit 12 attributes and static data providers.
- Fixing test failures by using a consistent `\n` line separator and updating byte-offset assertions.
- Migrating `phpunit.dist.xml` to the new format required by PHPUnit 12.
- Deleting temporary backup files and verifying all tests pass.

---
*PR created automatically by Jules for task [13031103489280311536](https://jules.google.com/task/13031103489280311536) started by @flaviu-chelaru*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded minimum PHP version requirement to 8.3.
  * Updated development dependencies: PHPUnit to version 12.0 and Rector to version 2.0.
  * Modernized internal code structure using PHP 8+ features for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->